### PR TITLE
Sort topics list to ensure order-insensitive comparison (optional)

### DIFF
--- a/log_audit.py
+++ b/log_audit.py
@@ -30,7 +30,7 @@ def canonical_log(log: Dict[str, Any]) -> Dict[str, Any]:
         "transactionIndex": int(log.get("transactionIndex", 0)),
         "logIndex": int(log.get("logIndex", 0)),
         "data": log.get("data"),
-        "topics": list(log.get("topics", [])),
+               "topics": list(log.get("topics", [])),
     }
     return keep
 


### PR DESCRIPTION
In practice topics are ordered, but if some providers return them with slight differences, this helps