### PR TITLE
Handle KeyboardInterrupt nicely

### DIFF
--- a/quick_audit.py
+++ b/quick_audit.py
@@ -91,4 +91,9 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nAborted by user.", file=sys.stderr)
+        sys.exit(130)
+


### PR DESCRIPTION
Avoid ugly stack traces when user hits Ctrl+C.