### PR TITLE
Bugfix: remove manual sys.argv parsing and rely on argparse in log_au…

### DIFF
--- a/log_audit.py
+++ b/log_audit.py
@@ -103,12 +103,6 @@ def main():
     rpcB = args.rpcB
 
 
-    from_block = int(sys.argv[1])
-    to_block = int(sys.argv[2])
-    address = sys.argv[3]
-    topic0 = sys.argv[4]
-    rpcA = sys.argv[5] if len(sys.argv) > 5 else DEFAULT_RPC_A
-    rpcB = sys.argv[6] if len(sys.argv) > 6 else DEFAULT_RPC_B
 
     if from_block < 0 or to_block < 0:
         print("❌ Blocks must be ≥ 0.")


### PR DESCRIPTION
…dit.py

## Summary

`log_audit.py` currently parses CLI arguments twice:

1. First using `argparse` in `build_parser()` / `parser.parse_args()`.
2. Then immediately overrides those values with `sys.argv[...]` manually.

This can lead to surprising bugs (e.g. incorrect argument ordering, ignoring `--rpcA/--rpcB` options) and makes the CLI harder to maintain.

This PR removes the manual `sys.argv` parsing and uses only the `argparse` results.

## Changes

- In `log_audit.py`, delete the block that reassigns `from_block`, `to_block`, `address`, `topic0`, `rpcA`, and `rpcB` from `sys.argv`.
- Keep the values taken from `args` (the parsed arguments) as the single source of truth.

## Rationale

- `argparse` already handles positional and optional args safely.
- Avoids subtle bugs if the argument order changes.
- Makes the CLI interface clearer and easier to extend (e.g. when adding new flags).

## Testing

- Run `python log_audit.py 100 110 0x0000000000000000000000000000000000000000 0x* --rpcA ... --rpcB ...`
- Confirm that:
  - The script uses the supplied args correctly.
  - Behavior matches expectations (previous behavior, minus the double parsing).