### PR TITLE
Bugfix: align quick_audit.py wrapper with log_audit.py CLI and env vars

### DIFF
--- a/quick_audit.py
+++ b/quick_audit.py
@@ -46,8 +46,8 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    rpc_a = args.rpc_a or os.getenv("LOG_RPC_A")
-    rpc_b = args.rpc_b or os.getenv("LOG_RPC_B")
+   rpc_a = args.rpc_a or os.getenv("RPC_A")
+rpc_b = args.rpc_b or os.getenv("RPC_B")
 
     if not rpc_a or not rpc_b:
         print(
@@ -64,18 +64,20 @@ def main() -> None:
         print(f"ERROR: log_audit.py not found next to {__file__}", file=sys.stderr)
         sys.exit(1)
 
-    cmd = [
-        sys.executable,
-        str(log_audit_path),
-        "--rpc-a",
-        rpc_a,
-        "--rpc-b",
-        rpc_b,
-        "--from-block",
-        str(args.from_block),
-        "--to-block",
-        str(args.to_block),
-    ]
+ address = args.address or "*"
+topic0 = args.topic0 or "*"
+
+cmd = [
+    sys.executable,
+    str(log_audit_path),
+    str(args.from_block),
+    str(args.to_block),
+    address,
+    topic0,
+    "--rpcA", rpc_a,
+    "--rpcB", rpc_b,
+]
+
 
     if args.address:
         cmd += ["--address", args.address]


### PR DESCRIPTION
## Summary

`quick_audit.py` is intended as a small convenience wrapper around `log_audit.py`, but currently:

- It passes flags like `--rpc-a`, `--rpc-b`, `--from-block`, `--to-block`, which `log_audit.py` does not accept.
- It reads RPC URLs from `LOG_RPC_A` / `LOG_RPC_B`, whereas `log_audit.py` uses `RPC_A` / `RPC_B` as defaults.

As a result, `quick_audit.py` does not work out-of-the-box.

This PR makes `quick_audit.py` compatible with the actual CLI of `log_audit.py` and aligns environment variable usage.

## Changes

- Update `quick_audit.py` to:
  - Read RPC defaults from the same env vars as `log_audit.py` (`RPC_A` / `RPC_B`).
  - Call `log_audit.py` using:
    - positional args: `from_block`, `to_block`, `address`, `topic0`
    - options: `--rpcA` and `--rpcB` (matching `build_parser()`).
  - If `address` or `topic0` are omitted, pass `"*"` so that the filters behave as wildcards.

## Rationale

- Makes `quick_audit.py` usable without changing `log_audit.py`.
- Keeps the wrapper small and simple while respecting the main script’s interface.
- Avoids confusion for users who expect the wrapper to “just work”.

## Example

```bash
export RPC_A=https://mainnet.infura.io/v3/your_key
export RPC_B=https://eth.llamarpc.com

python quick_audit.py --from-block 10000000 --to-block 10000100